### PR TITLE
Auto layer selection

### DIFF
--- a/src/napari_z_plotter/_widget.py
+++ b/src/napari_z_plotter/_widget.py
@@ -60,7 +60,7 @@ class DepthLineProfileWidget(QWidget):
     @property
     def data_layers(self):
         return [layer for layer in self.viewer.layers
-                if isinstance(layer, napari.layers.Image) & (layer.data.ndim == 3) & (layer.rgb == False)]
+                if isinstance(layer, napari.layers.Image) and (layer.data.ndim == 3) and (layer.rgb is False)]
 
     def _on_layer_change(self, e):
         """

--- a/src/napari_z_plotter/_widget.py
+++ b/src/napari_z_plotter/_widget.py
@@ -95,12 +95,14 @@ class DepthLineProfileWidget(QWidget):
                 z_range = np.arange(max_z) * z_scale + z_shift
 
                 # List of lines to add
-                line_profiles += [[z_range, image_transposed[:, y, x]]]
+                line_profiles += [[z_range, image_transposed[:, y, x], {'label': layer.name}]]
 
         self.axes.cla()
-        [self.axes.plot(*line_profile) for line_profile in line_profiles]
+        [self.axes.plot(line_profile[0], line_profile[1], **line_profile[2]) for line_profile in line_profiles]
         self._slice_indicator = self.axes.axvline(self.z_data_range[z], linestyle='--', color='grey')
         self.axes.set_xlim(min(self.z_data_range), max(self.z_data_range))
+        if len(line_profiles) > 1:
+            self.axes.legend()
         self.canvas.draw()
 
     def _on_slice_change(self, event):

--- a/src/napari_z_plotter/_widget.py
+++ b/src/napari_z_plotter/_widget.py
@@ -1,8 +1,6 @@
 from qtpy.QtWidgets import (
     QWidget,
-    QComboBox,
     QSizePolicy,
-    QLabel,
     QGridLayout,
 )
 from qtpy.QtCore import Qt
@@ -22,11 +20,6 @@ class DepthLineProfileWidget(QWidget):
         grid_layout = QGridLayout()
         grid_layout.setAlignment(Qt.AlignTop)
         self.setLayout(grid_layout)
-
-        self.cb_image = QComboBox()
-        self.cb_image.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
-        grid_layout.addWidget(QLabel("3D Image", self), 0, 0)
-        grid_layout.addWidget(self.cb_image, 0, 1)
 
         self.canvas = FigureCanvas()
         self.canvas.figure.set_tight_layout(True)
@@ -57,52 +50,56 @@ class DepthLineProfileWidget(QWidget):
     def z_data_range(self):
         dims_range = np.array(self.viewer.dims.range, dtype='int')[self.axis][0]
         return np.arange(*dims_range)
-    
+
     @property
     def axis(self):
         axis = list(self.viewer.dims.displayed)
         axis.insert(0, list(set([0, 1, 2]) - set(self.viewer.dims.displayed))[0])
-        
         return axis
+
+    @property
+    def data_layers(self):
+        return [layer for layer in self.viewer.layers
+                if isinstance(layer, napari.layers.Image) & (layer.data.ndim == 3) & (layer.rgb == False)]
 
     def _on_layer_change(self, e):
         """
-        Called when a new layer is inserted, removed, or renamed. Updates the layer combobox.
+        Called when a new layer is inserted, removed, or renamed.
+        Binds mouse click event to _on_mouse_click.
         """
-        self.cb_image.clear()
-        for x in self.viewer.layers:
-            if isinstance(x, napari.layers.Image) & (x.data.ndim == 3) & (x.rgb == False):
-                self.cb_image.addItem(x.name, x.data)
-                if self._on_mouse_click not in x.mouse_drag_callbacks:
-                    x.mouse_drag_callbacks.append(self._on_mouse_click)
+        for layer in self.data_layers:
+            if self._on_mouse_click not in layer.mouse_drag_callbacks:
+                layer.mouse_drag_callbacks.append(self._on_mouse_click)
 
     def _on_mouse_click(self, source_layer, event):
         """
         Called when the user clicks in the image. Updates the line plot.
         """
-        image_data = source_layer.data
-        if image_data is None:
-            return
-
         # Check that we are in 2D mode
         if len(event.dims_displayed) != 2:
             return
 
-        # Take care of the transpose state of the image of in the viewer
-        z, y, x = np.array(source_layer.world_to_data(event.position), dtype=np.int_)[self.axis]
+        line_profiles = []
+        for layer in self.data_layers:
+            # Check if position on layer
+            z, y, x = np.array(layer.world_to_data(event.position), dtype=np.int_)[self.axis]
+            max_z, max_y, max_x = np.array(layer.data.shape)[self.axis]
 
-        image_transposed = image_data.transpose(self.axis)
-        _, max_y, max_x = image_transposed.shape
+            if (0 <= y <= max_y) & (0 < x < max_x):
+                # Take care of the transpose state of the image of in the viewer
+                image_transposed = layer.data.transpose(self.axis)
 
-        # Check that the click is not outside the image
-        if not (0 <= y <= max_y) & (0 < x < max_x):
-            return
+                # Determine z-range of each layer
+                z_shift = layer.translate[self.axis[0]]
+                z_scale = layer.scale[self.axis[0]]
+                z_range = np.arange(max_z) * z_scale + z_shift
 
-        line_profile = image_transposed[:, y, x]
+                # List of lines to add
+                line_profiles += [[z_range, image_transposed[:, y, x]]]
 
         self.axes.cla()
-        self.axes.plot(self.z_data_range, line_profile)
-        self.axes.axvline(self.z_data_range[z], linestyle='--', color='grey')
+        [self.axes.plot(*line_profile) for line_profile in line_profiles]
+        self._slice_indicator = self.axes.axvline(self.z_data_range[z], linestyle='--', color='grey')
         self.axes.set_xlim(min(self.z_data_range), max(self.z_data_range))
         self.canvas.draw()
 
@@ -110,9 +107,11 @@ class DepthLineProfileWidget(QWidget):
         """
         Called when the user changes the slice slider. Updates the line plot. Update vline.
         """
-        line_position = self.z_data_range[event.value[self.axis[0]]]
+        # prevent error if last layer is unloaded
+        if self.data_layers:
+            line_position = self.z_data_range[event.value[self.axis[0]]]
 
-        if len(self.axes.lines) > 0:
-            self.axes.lines[1].set(xdata=[line_position]*2, visible=True)
+            if len(self.axes.lines) > 0:
+                self._slice_indicator.set(xdata=[line_position]*2, visible=True)
 
-        self.canvas.draw()
+            self.canvas.draw()


### PR DESCRIPTION
This version allows to automatically chooses the image layer clicked on for the plotting. If multiple layers are on top of each other all of them will be plotted. This makes the plugin much more user-friendly for multiple layers tiling in x,y or z.

In addition, small fixes:
- correct behavior for transformed z-axis
- preventing crashing for label-layers
- preventing crashing if all layers are unloaded